### PR TITLE
A major cleanup of the smartsearch JS code

### DIFF
--- a/js/smartsearch-autocomplete.js
+++ b/js/smartsearch-autocomplete.js
@@ -58,6 +58,4 @@ jQuery(function ($) {
             }
         }
     });
-
-    
 });

--- a/js/smartsearch-globals.js
+++ b/js/smartsearch-globals.js
@@ -30,8 +30,7 @@ jQuery(function ($) {
         window._paq.push(['trackPageView']);
     }
 
-    window.createPager = function (totalPages) {
-        var actualPage = window.actualPage ?? 1;
+    window.createPager = function (totalPages, actualPage) {
         $('#smartsearch-pager').empty();
         var startPage = Math.max(actualPage - 2, 1);
         var endPage = Math.min(startPage + 3, totalPages);

--- a/js/smartsearch-map.js
+++ b/js/smartsearch-map.js
@@ -103,9 +103,12 @@ jQuery(function ($) {
         });
     }
 
-    window.mapToggle = function() {
-        $('.sm-map').css('top', $('.sm-map').css('top') == '0px' ? -3000 : 0);
-        $('.sm-map').css('position', $('.sm-map').css('position') == 'absolute' ? 'inherit' : 'absolute');
+    window.mapToggle = function(show) {
+        if (show === undefined) {
+            show = $('.sm-map').css('top') != '0px';
+        }
+        $('.sm-map').css('top', show ? 0 : -3000);
+        $('.sm-map').css('position', show ? 'inherit' : 'absolute');
         window.setTimeout(function () {window.map.invalidateSize();}, 100);
     }
 

--- a/js/smartsearch-map.js
+++ b/js/smartsearch-map.js
@@ -2,19 +2,16 @@ jQuery(function ($) {
 
     "use strict";
 
-    var markersArr = [];
-    window.map;
-
-    window.initializeMaps = function (reinit = false) {
-        map = L.map('map').setView([48.2, 16.3], 10);
+    window.initializeMaps = function () {
+        window.map = L.map('map').setView([48.2, 16.3], 10);
 
         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        }).addTo(map);
+        }).addTo(window.map);
 
         // FeatureGroup is to store editable layers
-        var drawnItems = new L.FeatureGroup();
-        map.addLayer(drawnItems);
+        window.searchArea = new L.FeatureGroup();
+        window.map.addLayer(window.searchArea);
 
         // Initialize the draw control and pass it the FeatureGroup of editable layers
         var drawControl = new L.Control.Draw({
@@ -34,81 +31,12 @@ jQuery(function ($) {
             edit: {
                 remove: false,
                 edit: false,
-                featureGroup: drawnItems
+                featureGroup: window.searchArea
             }
         });
-        map.addControl(drawControl);
+        window.map.addControl(drawControl);
 
-        if (!reinit) {
-            var coordinates = (window.guiObj.facets !== undefined && window.guiObj.facets.map !== undefined) ? window.guiObj.facets.map : "";
-            if (coordinates) {
-                var coordinatesString = coordinates.replace('POLYGON((', '').replace('))', '');
-                var coordinatesArray = coordinatesString.split(',');
-
-                // Reformat the coordinates to [latitude, longitude] for Leaflet
-                var polygonCoordinates = coordinatesArray.map(function (coord) {
-                    var latLng = coord.trim().split(' ');
-                    return [parseFloat(latLng[1]), parseFloat(latLng[0])];
-                });
-
-                var latitudes = polygonCoordinates.map(function (coord) {
-                    return coord[0];
-                });
-                var longitudes = polygonCoordinates.map(function (coord) {
-                    return coord[1];
-                });
-
-                var southWest = [Math.min.apply(null, latitudes), Math.min.apply(null, longitudes)];
-                var northEast = [Math.max.apply(null, latitudes), Math.max.apply(null, longitudes)];
-
-                var bounds = [southWest, northEast];
-
-                // Create a rectangle layer
-                var rectangle = L.rectangle(bounds, {
-                    fillColor: '#97009c'
-                });
-
-                //map.addLayer(drawnItems);
-                drawnItems.addLayer(rectangle);
-                drawnItems.addTo(map);
-
-                setTimeout(function () {
-                    window.setMapLabel(drawnItems);
-                }, 1000);
-
-                map.fitBounds(rectangle.getBounds());
-            }
-        }
-
-        map.on(L.Draw.Event.CREATED, function (event) {
-            drawnItems.clearLayers();
-            window.bboxObj = {};
-            var layer = event.layer;
-            map.removeLayer(layer);
-            drawnItems.addLayer(layer);
-
-            window.bboxObj = {drawnItems};
-            window.setMapLabel(drawnItems);
-        });
-
-        map.on('draw:drawstart', function (event) {
-            var layer = event.layer;
-            if (layer) {
-                map.removeLayer(layer);
-                drawnItems.clearLayers();
-            }
-        });
-
-        map.on('draw:deleted', function (event) {
-            var layer = event.layer;
-            map.removeLayer(layer);
-            $('#mapLabel').html('');
-            $('.sm-map').css('top', '-3000px');
-            $('.sm-map').css('display', 'block');
-        });
-
-        window.bbox = drawnItems;
-
+        // Custom map close button
         var customCloseControl = L.Control.extend({
             options: {
                 position: 'topright' // Position the button in the top right corner
@@ -128,22 +56,14 @@ jQuery(function ($) {
                 L.DomEvent.disableClickPropagation(container);
 
                 // Setup the click event on the button
-                L.DomEvent.on(container, 'click', function () {
-                    $('.sm-map').css('top', $('.sm-map').css('top') == '0px' ? -3000 : 0);
-                    $('.sm-map').css('position', $('.sm-map').css('position') == 'absolute' ? 'inherit' : 'absolute');
-
-                    setTimeout(function () {
-                        map.invalidateSize();  // 'map' is your Leaflet map variable
-                    }, 100);
-                });
+                L.DomEvent.on(container, 'click', function() {window.mapToggle();});
 
                 return container;
             }
         });
-        // Add the custom button to the map
-        map.addControl(new customCloseControl());
+        window.map.addControl(new customCloseControl());
 
-        // Create a custom button for deleting all layers
+        // Custom search area delete button
         var customDeleteControl = L.Control.extend({
             options: {
                 position: 'topleft'
@@ -162,8 +82,7 @@ jQuery(function ($) {
                 container.innerHTML = '<img class="smartsearch_trash_icon" src="/browser/modules/contrib/arche_core_gui/images/trash_icon.png"/>'; // Trash icon (can be replaced with an image or text)
 
                 container.onclick = function () {
-                    drawnItems.clearLayers();
-                    $('#mapLabel').html('');
+                    window.mapRemoveSearchArea();
                 };
 
                 // Prevent click propagation to the map
@@ -172,178 +91,35 @@ jQuery(function ($) {
                 return container;
             }
         });
+        window.map.addControl(new customDeleteControl());
 
-        // Add the new control to the map
-        map.addControl(new customDeleteControl());
-    }
-
-
-    window.initializeMap = function () {
-        //function initializeMap() {
-        $(".map-loader").css('display', 'block');
-        map = L.map('map', {
-            zoomControl: false, // Add zoom control separately below
-            center: [48.2, 16.3], // Initial map center
-            zoom: 10, // Initial zoom level
-            attributionControl: false, // Instead of default attribution, we add custom at the bottom of script
-            scrollWheelZoom: false
+        // search area draw events
+        window.map.on(L.Draw.Event.DRAWSTART, function (event) {
+            window.searchArea.clearLayers();
         });
-
-        // Add zoom in/out buttons to the top-right
-        L.control.zoom({position: 'topright'}).addTo(map)
-
-        setTimeout(function () {
-            // Add baselayer
-            L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png', {
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-                subdomains: 'abcd',
-                maxZoom: 19
-            }).addTo(map)
-
-            // Add geographical labels only layer on top of baselayer
-            var labels = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}{r}.png', {
-                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
-                subdomains: 'abcd',
-                maxZoom: 19,
-                pane: 'shadowPane'  // always display on top
-            }).addTo(map)
-
-        }, 500);
-
-        setTimeout(function () {
-            fetch(window.archeBaseUrl + '/browser/api/search_coordinates/' + drupalSettings.arche_core_gui.gui_lang + '?_format=json')
-                    .then((response) => response.json())
-                    .then((data) => {
-                        var heatArr = [];
-
-                        $.each(data, function (index, markerData) {
-                            if (markerData['lon'] && markerData['lat'] && markerData['wkt']) {
-                                var lon = markerData['lon'];
-                                var lat = markerData['lat'];
-                                var wkt = markerData['wkt'];
-                                var cityName = markerData['title'];
-
-                                var marker = L.marker([lat, lon], {
-                                    title: cityName, // Set the title property
-                                })
-                                        .bindPopup('<h5>' + cityName + '</h5><br><a href="#" id="SMMapBtn" class="btn btn-arche-blue w-100 text-light" data-coordinates="' + wkt + '" data-location-title="' + cityName + '">Add to Search</a>')
-                                        .addTo(map);
-                                heatArr.push([lat, lon]);
-                                // Add the marker to the array
-                                markersArr.push(marker);
-                            }
-                        });
-
-                        var heat = L.heatLayer(data, {
-                            radius: 100,
-                            blur: 10
-                        })
-
-                        // Add the heatlayer to the map
-                        heat.addTo(map);
-                        $(".map-loader").css('display', 'none');
-                    })
-                    .catch((error) => {
-                        console.error('Error loading JSON data: ', error);
-                        $(".map-loader").css('display', 'none');
-                        $(".sms-map.leaflet-container").html(error);
-
-                        return;
-                    });
-        }, 2000);
-    }
-
-
-    // Function to destroy the map
-    function destroyMap() {
-        if (map) {
-            map.remove();
-            map = null;
-        }
-    }
-
-    function filterMarkers(query) {
-        query = query.toLowerCase();
-        // Clear previous search results
-        $("#smMapSearchResults").empty();
-        // Filter markers and display matching ones
-        markersArr.forEach(function (marker) {
-            var markerName = marker.options.title.toLowerCase();
-            if (markerName.includes(query)) {
-                $('.smMapSearchResultsContainer').show();
-                marker.addTo(map);
-                $("#smMapSearchResults").append("<p>" + marker.options.title + "</p>");
-            } else {
-                map.removeLayer(marker);
-            }
+        window.map.on(L.Draw.Event.CREATED, function (event) {
+            window.searchArea.addLayer(event.layer);
+            window.mapRefreshLabel();
         });
     }
 
-    /**
-     * 
-     * @returns {undefined}
-     */
-    window.displayMapSelectedValue = function () {
-        //function displayMapSelectedValue() {
-        window.bbox = window.guiObj.coordinates;
-        if (window.guiObj.coordinates && window.guiObj.locationTitle) {
-            $('#mapSelectedPlace').html('<h5 class="h5-blue-title"><button id="removeMapSelectedPlace" class="btn btn-sm-add"> - </button>' + window.guiObj.locationTitle + '</h5>');
-        }
+    window.mapToggle = function() {
+        $('.sm-map').css('top', $('.sm-map').css('top') == '0px' ? -3000 : 0);
+        $('.sm-map').css('position', $('.sm-map').css('position') == 'absolute' ? 'inherit' : 'absolute');
+        window.setTimeout(function () {window.map.invalidateSize();}, 100);
     }
 
-
-
-    /**** EVENTS ***/
-
-    $("#searchInput").on("input", function () {
-        var query = $(this).val().toLowerCase();
-        filterMarkers(query);
-    });
-
-    // Function to jump to a marker when it's clicked in the search results
-    $("#smMapSearchResults").on("click", "p", function () {
-        var markerTitle = $(this).text();
-        $('.smMapSearchResultsContainer').hide();
-
-        markersArr.forEach(function (marker) {
-            if (marker.options.title.toLowerCase() === markerTitle.toLowerCase()) {
-                var latlng = marker.getLatLng();
-                map.setView(latlng, 13); // Set the view to the marker's coordinates
-            }
-        });
-    });
-
-
-    $('#resetSMSMapButton').click(function (e) {
-        e.preventDefault();
-        destroyMap(); // Destroy the map when hiding
-        window.initializeMaps();
-    });
-
-    $('#closeSMSMapButton').click(function () {
-        var mapContainer = $('#mapContainer');
-        mapContainer.hide();
-        destroyMap(); // Destroy the map when hiding
-    });
-
-    $('#mapToggleBtn').click(function () {
-        var mapContainer = $('#mapContainer');
-
-        if (mapContainer.is(':visible')) {
-            mapContainer.hide();
-            destroyMap(); // Destroy the map when hiding
-        } else {
-            mapContainer.show();
-            if (!map) {
-                window.initializeMaps(); // Initialize the map when showing
-            }
-        }
-    });
-
-    window.setMapLabel = function (bbox) {
-        //function setMapLabel(bbox) {
-        var coord = bbox.getLayers()[0].toGeoJSON().geometry.coordinates[0];
-        $('#mapLabel').html('<div class="mapLabelDiv"><a href="#" id="mapRemoveFiltersBtn"><img src="/browser/modules/contrib/arche_core_gui/images/trash_icon.png" class="smartsearch_trash_icon"></a> ' + coord[0][0].toPrecision(3) + ', ' + coord[0][1].toPrecision(3) + ' - ' + coord[2][0].toPrecision(3) + ', ' + coord[2][1].toPrecision(3) + '</div>');
+    window.mapRemoveSearchArea = function() {
+        window.searchArea.clearLayers();
+        window.mapRefreshLabel();
     }
 
+    window.mapRefreshLabel = function () {
+        var coord = window.searchArea.getBounds();
+        var label = '';
+        if (coord._northEast) {
+            label = '<div class="mapLabelDiv"><a href="#" id="mapRemoveFiltersBtn"><img src="/browser/modules/contrib/arche_core_gui/images/trash_icon.png" class="smartsearch_trash_icon"></a> ' + coord.getWest().toPrecision(3) + ', ' + coord.getSouth().toPrecision(3) + ' - ' + coord.getEast().toPrecision(3) + ', ' + coord.getNorth().toPrecision(3) + '</div>';
+        }
+        $('#mapLabel').html(label);
+    }
 });

--- a/js/smartsearch-result.js
+++ b/js/smartsearch-result.js
@@ -53,6 +53,7 @@ jQuery(function ($) {
             window.displaySearchWarningMessage(data.messages, data.class);
         }
         
+        window.mapToggle(false);
         if (param.facets['map']) {
             var coords = param.facets['map'].replace('POLYGON((', '').replace('))', '');
             coords = coords.split(',');
@@ -60,7 +61,8 @@ jQuery(function ($) {
             window.searchArea.clearLayers();
             window.searchArea.addLayer(L.polygon(coords));
             window.map.fitBounds(window.searchArea.getBounds());
-            window.mapToggle();
+            window.mapToggle(true);
+            window.mapRefreshLabel();
         }
 
         if (data.allPins) {

--- a/js/smartsearch-result.js
+++ b/js/smartsearch-result.js
@@ -1,84 +1,162 @@
 jQuery(function ($) {
 
     var mapPins = null;
+    var mapPinsAll = null;
 
     /**
      * Display the smartsearch results
      * @param {type} data
      * @param {type} param
      * @param {type} t0
-     * @param {type} initial
      * @returns {undefined}
      */
-    window.showResults = function (data, param, t0, initial = false) {
-       
-        //function showResults(data, param, t0, initial = false) {
+    window.showResults = function (data, param, t0) {
         t0 = (new Date() - t0) / 1000;
-        data = jQuery.parseJSON(data);
         var pageSize = data.pageSize;
         var totalPages = Math.ceil(data.totalCount / pageSize);
-        var currentPage = $('a.paginate_button.current').text();
+        var currentPage = Math.max(1, data.page + 1);
         
-        if (!currentPage && data.page === 0) {
-            currentPage = 1;
-        } else {
-            currentPage = data.page;
-        }
-
         window.createPager(totalPages);
         $('div.dateValues').text('');
         $('input.facet-min').attr('placeholder', '');
         $('input.facet-max').attr('placeholder', '');
+        $('#sm-hero-str').val(param.q);
+        $('#linkNamedEntities').prop('checked', parseInt(param.linkNamedEntities) === 1);
+        $('#inBinary').prop('checked', parseInt(param.includeBinaries) === 1);
         var results = '';
-        //we have some results already or empty search
+        // we have some results already or empty search
         if ((data.totalCount > 0) || data.totalCount === -1) {
             createFacetCards(data, param);   
         }
 
         if(data.results) {
-            results += displaySearchResult(data.results);
+            results += '<div class="container">';
+            $.each(data.results, function (k, result) {
+                if (result.title && result.id) {
+                    results += window.getResourceCard(result);
+                }
+            });
+
             $('.main-content-row').html(results);
-            //if the user selected a value from the map then we have to display it.
-            window.displayMapSelectedValue();
         }
         
-        //var countText = countNullText;
-        if (!initial) {
-            var countText = Drupal.t('0 Result(s)');
-            if (data.results.length > 0) {
-                countText = data.totalCount + ' ' + Drupal.t("Result(s)");
-            } else {
-                $('.main-content-row .container').html('<div class="alert alert-warning" role="alert">' + Drupal.t("No result! Please start a new search!") + "</div>");
-                //showJustSearchFacets();
-            }
-            $('#smartSearchCount').html(countText);
+        var countText = Drupal.t('0 Result(s)');
+        if (data.results.length > 0) {
+            countText = data.totalCount + ' ' + Drupal.t("Result(s)") + ' ' + t0.toPrecision(2) + 's';
         } else {
-            $('#smartSearchCount').html('0 ' + Drupal.t("Result(s)"));
-            $('.main-content-row .container').html('<div class="alert alert-primary" role="alert">' + Drupal.t("Please start to search") + "</div>");
+            $('.main-content-row .container').html('<div class="alert alert-warning" role="alert">' + Drupal.t("No result! Please start a new search!") + "</div>");
         }
+        $('#smartSearchCount').html(countText);
 
-        //display warnings 
+        // display warnings 
         if (data.messages !== "") {
             window.displaySearchWarningMessage(data.messages, data.class);
         }
         
-        if (window.bboxObj !== undefined) {
-            if (window.bboxObj.drawnItems) {
-                setMapLabel(window.bboxObj.drawnItems);
-            }
+        if (param.facets['map']) {
+            var coords = param.facets['map'].replace('POLYGON((', '').replace('))', '');
+            coords = coords.split(',');
+            coords = coords.map(function(x) {return x.split(' ').reverse();}); // leaflet takes lat,lon while WKT is lon,lat
+            window.searchArea.clearLayers();
+            window.searchArea.addLayer(L.polygon(coords));
+            window.map.fitBounds(window.searchArea.getBounds());
+            window.mapToggle();
         }
 
-        if (window.bbox !== undefined) {
-            setMapLabel(window.bbox);
+        if (data.allPins) {
+            if (mapPinsAll) {
+                window.map.removeLayer(mapPinsAll);
+            }
+            mapPinsAll = L.geoJSON(JSON.parse(data.allPins));
+            mapPinsAll.addTo(window.map);
         }
-        
-        if(param.searchIn[0]) {
-            window.searchInAdd(param.searchIn[0], $(this).data('resource-title'));
+
+        if (data.searchIn && data.searchIn.length > 0) {
+            $('#searchIn').html(window.getResourceCard(data.searchIn[0], true));
             $('#searchIn').show();
+            window.searchIn = [data.searchIn[0].id];
         }
-        
+
         $(".discover-left input, .discover-left textarea, .discover-left select, .discover-left button").prop("disabled", false);
-        window.updateUrl(param);           
+    }
+
+    window.getResourceCard = function(result, searchIn) {
+        var resourceUrl = result.url.replace(/(https?:\/\/)/g, '');
+        searchIn = searchIn || false;
+
+        var id = searchIn ? 'in' + result.id : 'res' + result.id;
+        var searchInBtnId = searchIn ? 'removeSearchInElementBtn' : result.id;
+        var searchInBtnLabel = searchIn ? '-' : '+';
+
+        results = '';
+        results += '<div class="row smart-result-row" id="' + id + '" data-value="' + result.id + '">';
+        results += '<div class="col-block col-lg-10 discover-table-content-div" data-contentid="' + resourceUrl + '">';
+
+        //<-- title part
+        results += '<div class="res-property">';
+        results += '<h5 class="h5-blue-title">';
+        results += '<button type="button" class="btn btn-sm-add searchInBtn" data-resource-id="' + searchInBtnId + '">' + searchInBtnLabel + '</button>';
+        results += '<a href="' + archeBaseUrl + '/browser/metadata/' + result.id + '" taget="_blank">' + getLangValue(result.title, preferredLang) + '</a>';
+        results += '</h5>';
+        results += '</div>';
+        //-->
+
+        if (result.description) {
+            results += '<div class="res-property sm-description">';
+            results += window.getLangValue(result.description, window.preferredLang);
+            results += '</div>';
+        }
+
+        results += '<div class="res-property sm-highlight">';
+        if (result.matchHighlight) {
+            results += 'Highlight: ' + result.matchHighlight;
+        }
+        //results += 'Match score: ' + result.matchWeight + '<br/>';
+        if (result.matchProperty.length > 0) {
+            results += 'Matches in:<div class="ml-5">';
+            for (var j = 0; j < result.matchProperty.length; j++) {
+                if (result.matchHiglight && result.matchHiglight[j]) {
+                    results += shorten(result.matchProperty[j] || '') + ': ' + result.matchHiglight[j] + '<br/>';
+                } else {
+                    results += shorten(result.matchProperty[j] || '') + '<br/>';
+                }
+            }
+            results += '</div>';
+        }
+        results += getParents(result.parent || false, true, window.preferredLang);
+        results += '</div>';
+
+        results += '<div class="res-property discover-content-toolbar">';
+        results += '<p class="btn-toolbar-gray btn-toolbar-text no-btn">' + shorten(result.class[0]) + '</p>';
+
+        if (result.accessRestriction) {
+            results += window.setAccessRestrictionLabel(result.accessRestriction[0].title['en']);
+            results += result.accessRestriction[0].title[window.preferredLang].replace(/\n/g, ' / ');
+            results += '</p>';
+        }
+
+        if (result.accessRestrictionSummary) {
+            results += window.setAccessRestrictionLabel(result.accessRestrictionSummary['en']);
+            results += result.accessRestrictionSummary[window.preferredLang].replace(/\n/g, ' / ');
+            results += '</p>';
+        }
+
+        results += '</div>';
+        results += '</div>';
+                
+        var thumbImgUrl = result.url.replace('/browser/metadata/', '/api/');
+        results += '<div class="col-lg-2" data-thumbnailid="' + resourceUrl + '">' +
+                '<div class="col-block discover-table-image-div">\n\
+                            <div class="dt-single-res-thumb text-center" style="min-width: 120px;">\n\
+                                <center><a href="https://arche-thumbnails.acdh.oeaw.ac.at?id=' + thumbImgUrl  + '&width=600" data-lightbox="detail-titleimage-' + result.id + '">\n\
+                                <img class="img-fluid" src="https://arche-thumbnails.acdh.oeaw.ac.at?id=' + thumbImgUrl  + '&width=200" onerror="window.hideThumbnail(this)" data-resourceurl="' + resourceUrl + '">\n\
+                                </a></center>\n\
+                            </div>\n\
+                        </div>';
+
+        results += '</div>';
+        results += '</div>';
+        return results;
     }
 
     function createFacetCards(data, param) {
@@ -130,12 +208,12 @@ jQuery(function ($) {
 
                     if (fd.type === 'map') {
                         if (mapPins) {
-                            map.removeLayer(mapPins);
+                            window.map.removeLayer(mapPins);
                         }
                        
                         if (fd.values !== '') {
                             mapPins = L.geoJSON(JSON.parse(fd.values));
-                            mapPins.addTo(map);
+                            mapPins.addTo(window.map);
                         }
                         select = '<div id="mapLabel"></div>' +
                                 '<button type="button" id="mapToggleBtn" class="btn btn-arche-blue w-100">' + Drupal.t('Map') + '</button>';
@@ -207,91 +285,12 @@ jQuery(function ($) {
         return text;
     }
 
-    /**
-     * Generate HTML code for the result view
-     * @param {type} data
-     * @returns {String}
-     */
-    function displaySearchResult(data) {
-        var results = "";
-        results += '<div class="container">';
-
-        $.each(data, function (k, result) {
-            if (result.title && result.id) {
-                var resourceUrl = result.url.replace(/(https?:\/\/)/g, '');
-               
-                results += '<div class="row smart-result-row" id="res' + result.id + '" data-value="' + result.id + '">';
-                results += '<div class="col-block col-lg-10 discover-table-content-div" data-contentid="' + resourceUrl + '">';
-                //title
-                results += '<div class="res-property">';
-                results += '<h5 class="h5-blue-title"><button type="button" class="btn btn-sm-add searchInBtn" data-resource-id="' + result.id + '" data-resource-title="' + getLangValue(result.title, preferredLang) + '" >+</button><a href="' + archeBaseUrl + '/browser/metadata/' + result.id + '" taget="_blank">' + getLangValue(result.title, preferredLang) + '</a></h5>';
-                //results += '<h5 class="h5-blue-title"><a href="' + window.archeBaseUrl + '/browser/metadata/' + result.id + '" taget="_blank">' + window.getLangValue(result.title, window.preferredLang) + '</a></h5>';
-                results += '</div>';
-
-                //description
-                if (result.description) {
-                    results += '<div class="res-property sm-description">';
-                    results += window.getLangValue(result.description, window.preferredLang);
-                    results += '</div>';
-                }
-
-                results += '<div class="res-property sm-highlight">';
-                if (result.matchHighlight) {
-                    results += 'Highlight: ' + result.matchHighlight;
-                }
-
-                //results += 'Match score: ' + result.matchWeight + '<br/>';
-                if (result.matchProperty.length > 0) {
-                    results += 'Matches in:<div class="ml-5">';
-                    for (var j = 0; j < result.matchProperty.length; j++) {
-                        if (result.matchHiglight && result.matchHiglight[j]) {
-                            results += shorten(result.matchProperty[j] || '') + ': ' + result.matchHiglight[j] + '<br/>';
-                        } else {
-                            results += shorten(result.matchProperty[j] || '') + '<br/>';
-                        }
-                    }
-                    results += '</div>';
-                }
-
-                results += getParents(result.parent || false, true, window.preferredLang);
-
-                results += '</div>';
-                results += '<div class="res-property discover-content-toolbar">';
-
-                results += '<p class="btn-toolbar-gray btn-toolbar-text no-btn">' + shorten(result.class[0]) + '</p>';
-
-                if (result.accessRestriction) {
-                    results += window.setAccessRestrictionLabel(result.accessRestriction[0].title['en']);
-                    results += result.accessRestriction[0].title[window.preferredLang].replace(/\n/g, ' / ');
-                    results += '</p>';
-                }
-
-                if (result.accessRestrictionSummary) {
-                    results += window.setAccessRestrictionLabel(result.accessRestrictionSummary['en']);
-                    results += result.accessRestrictionSummary[window.preferredLang].replace(/\n/g, ' / ');
-                    results += '</p>';
-                }
-
-                results += '</div>';
-                results += '</div>';
-                
-                var thumbImgUrl = result.url.replace('/browser/metadata/', '/api/');
-                results += '<div class="col-lg-2" data-thumbnailid="' + resourceUrl + '">' +
-                        '<div class="col-block discover-table-image-div">\n\
-                                    <div class="dt-single-res-thumb text-center" style="min-width: 120px;">\n\
-                                        <center><a href="https://arche-thumbnails.acdh.oeaw.ac.at?id=' + thumbImgUrl  + '&width=600" data-lightbox="detail-titleimage-' + result.id + '">\n\
-                                        <img class="img-fluid" src="https://arche-thumbnails.acdh.oeaw.ac.at?id=' + thumbImgUrl  + '&width=200" >\n\
-                                        </a></center>\n\
-                                    </div>\n\
-                                </div>';
-
-                results += '</div>';
-                window.checkThumbnailImage(thumbImgUrl);
-                results += '</div>';
-            }
-        });
-        return results;
-    }
+    window.hideThumbnail = function(x) {
+        var resourceUrl = $(x).data('resourceurl');
+        $('[data-thumbnailid="' + resourceUrl + '"]').hide();
+        $('[data-contentid="' + resourceUrl + '"]').removeClass('col-lg-10');
+        $('[data-contentid="' + resourceUrl + '"]').addClass('col-lg-12');
+    };
 
     function getParents(parent, top, preferredLang) {
         if (parent === false) {
@@ -305,5 +304,4 @@ jQuery(function ($) {
         }
         return ret;
     }
-    
 });

--- a/js/smartsearch-result.js
+++ b/js/smartsearch-result.js
@@ -16,7 +16,7 @@ jQuery(function ($) {
         var totalPages = Math.ceil(data.totalCount / pageSize);
         var currentPage = Math.max(1, data.page + 1);
         
-        window.createPager(totalPages);
+        window.createPager(totalPages, currentPage);
         $('div.dateValues').text('');
         $('input.facet-min').attr('placeholder', '');
         $('input.facet-max').attr('placeholder', '');

--- a/js/smartsearch-url-func.js
+++ b/js/smartsearch-url-func.js
@@ -1,81 +1,32 @@
 jQuery(function ($) {
-   
-     $(document).ready(function () {
-         
-     });
-    
-    
-      /**
-     * Get the search param values from the guiObj
-     * @param {type} prop
-     * @returns {smartsearchL#1.guiObj|Array}
-     */
-    window.getGuiSearchParams = function (prop) {
-        //function getGuiSearchParams(prop) {
-        if (window.guiObj.hasOwnProperty(prop)) {
-            return window.guiObj[prop];
-        }
-    }
-    
-    window.getSearchParamsFromUrl = function (url) {
-        var paramsString = "";
-        if (url.split('/browser/discover?')[1]) {
-            paramsString = url.split('/browser/discover?')[1];
-        } else {
-            paramsString = url.split('/browser/discover/')[1];
-        }
-        paramsString = paramsString.replace('?q', 'q');
-        window.guiObj = {};
-        window.guiObj = window.parseQueryString(paramsString);
-        window.firstLoad = false;
-    }
-
     /**
-     * This function converts back the query string from the url into an object to the smartsearch api
-     * -- if we copy pasted the result url
+     * Parses the query string for the URL into a smartsearch configuration object
      * @param {type} queryString
-     * @returns {unresolved}
      */
     window.parseQueryString = function (queryString) {
-    //function parseQueryString(queryString) {
-        var myArray = [];
-        myArray = [];
-        var pairs = queryString.split('&');
-        pairs.forEach(function (pair) {
-            var parts = pair.split('=');
-            var key = decodeURIComponent(parts[0]);
-            var value = decodeURIComponent(parts[1]);
-            
-            // Handle array values within brackets
-            if (value.startsWith('[') && value.endsWith(']')) {
-                value = value.slice(1, -1).split(',');
-                /*
-                 * The sarchin first version was an array with multiple elements
-                 * but now we allow  only one and it is still an array so we have to take
-                 * the first element
-                 */
-                if(key === 'searchIn') {
-                    value = value[0];
-                }
-            }
-            // Handle nested keys
-            if (key.includes('[')) {
-                var keys = key.split(/[\[\]]+/).filter(Boolean);
-                var current = myArray;
-
-                for (var i = 0; i < keys.length; i++) {
-                    var nestedKey = keys[i];
-                    if (i === keys.length - 1) {
-                        current[nestedKey] = value;
-                    } else {
-                        current[nestedKey] = current[nestedKey] || {};
-                        current = current[nestedKey];
-                    }
-                }
+        var param = window.getSearchParamBase();
+        var urlParams = new URLSearchParams(queryString.replace(/^[/?]+/, ''));
+        urlParams.forEach(function (value, key) {
+            if (!key.includes('[')) {
+                param[key] = value;
             } else {
-                myArray[key] = value;
+                // Handle nested keys
+                var keys = key.replace(']', '').split('[');
+                var current = param;
+                var nestedKey;
+                while (keys.length > 1) {
+                    nestedKey = keys.shift();
+                    current[nestedKey] = current[nestedKey] || [];
+                    current = current[nestedKey];
+                }
+                nestedKey = keys.shift();
+                if (nestedKey === '') {
+                    current.push(value);
+                } else {
+                    current[nestedKey] = value;
+                }
             }
         });
-        return myArray;
+        return param;
     }
 });

--- a/js/smartsearch-url-func.js
+++ b/js/smartsearch-url-func.js
@@ -11,7 +11,7 @@ jQuery(function ($) {
                 param[key] = value;
             } else {
                 // Handle nested keys
-                var keys = key.replace(']', '').split('[');
+                var keys = key.replaceAll(']', '').split('[');
                 var current = param;
                 var nestedKey;
                 while (keys.length > 1) {

--- a/js/smartsearch.js
+++ b/js/smartsearch.js
@@ -9,8 +9,8 @@ jQuery(function ($) {
         window.initializeMaps();
 
         $(window).on('popstate', function (e) {
-            if (event.state !== undefined) {
-                window.search('none', event.state);
+            if (e.state !== undefined) {
+                window.search('none', e.state);
             }
         });
         var paramUrl = (new URL(window.location.href)).search.substring(1);

--- a/js/smartsearch.js
+++ b/js/smartsearch.js
@@ -56,6 +56,9 @@ jQuery(function ($) {
             window.searchIn = [];
         } else {
             window.searchIn = [id];
+            // hardcoded badly but lack of that really harms user experience
+            var typeFilter = $('[data-property="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]');
+            typeFilter.val(typeFilter.val().filter(function(x) { return x !== 'https://vocabs.acdh.oeaw.ac.at/schema#TopCollection'; }));
         }
         window.search();
     });


### PR DESCRIPTION
### Changes

* Remove unused functions (there were a lot e.g. in the maps code)
* Use the `history.pushState()`/`history.replaceState()` for handling the history back
* Use common codebase for GUI- and URL-triggered searches. The workflow now is as follows:
  * Every search (also a facets reset) calls the `search()` method first. A direct modification of the `window.location` is forbidden.
  * Based on the `search()` method call parameters, the search() method gathers backend call parameters either from a passed query string (using `parseQueryString()` which was slightly rewritten) or the GUI controls (using `collectBackendQueryParam()` which stayed almost as it was). Then it calls the backend and passed the response to the `showResults()`
  * `showResults()` updates the facets, displays the results, warnings, etc. To make it possible, the backend includes all the information required to render the searchIn GUI elements.
* The searchIn now just calls the search with the `searchIn` filter and the searchIn resource's GUI panel is rendered by the `showResults()` only.
* Cleanup maps code from copy-paste-infected boilerplate code

### Remarks

* It requires the "Discover button" URL to be changed to https://arche.acdh.oeaw.ac.at/browser/discover?preferredLang=en&includeBinaries=0&linkNamedEntities=1&page=0&pageSize=10&facets%5Bhttp%3A%2F%2Fwww.w3.org%2F1999%2F02%2F22-rdf-syntax-ns%23type%5D%5B%5D=https%3A//vocabs.acdh.oeaw.ac.at/schema%23TopCollection&noCache=0